### PR TITLE
Support for flag parameters in comments of a flag

### DIFF
--- a/src/tink/cli/DocFormatter.hx
+++ b/src/tink/cli/DocFormatter.hx
@@ -21,4 +21,5 @@ typedef DocFlag = {
 	aliases:Array<String>,
 	names:Array<String>,
 	doc:String,
+	paramDescription:String
 }

--- a/src/tink/cli/Macro.hx
+++ b/src/tink/cli/Macro.hx
@@ -39,7 +39,19 @@ class Macro {
 			
 			function s2e(v:String) return macro $v{v};
 			function f2e(fields) return EObjectDecl(fields).at();
-			
+			function getFlagParamDesc(doc : String) {
+				return if(doc != null) {
+					var ido = doc.indexOf('@param');
+					if(ido > -1) {
+						var iap = ido + 6;
+						StringTools.trim(doc.substr(iap, doc.indexOf('\n', iap) - iap));
+					} else {
+						"";
+					}
+				} else {
+					"";
+				}
+			}
 			for(command in info.commands) {
 				commands.push([
 					{field: 'isDefault', expr: macro $v{command.isDefault}},
@@ -54,6 +66,7 @@ class Macro {
 					{field: 'names', expr: macro $a{flag.names.map(s2e)}},
 					{field: 'aliases', expr: macro $a{flag.aliases.map(String.fromCharCode).map(s2e)}},
 					{field: 'doc', expr: macro $v{flag.field.doc}},
+					{field: 'paramDescription', expr: s2e(getFlagParamDesc(flag.field.doc))},
 				]);
 			}
 			

--- a/src/tink/cli/doc/DefaultFormatter.hx
+++ b/src/tink/cli/doc/DefaultFormatter.hx
@@ -71,20 +71,27 @@ class DefaultFormatter implements DocFormatter<String> {
 			
 			var maxFlagLength = spec.flags.fold(function(flag, max) {
 				var name = nameOf(flag);
+				if(flag.paramDescription.length > 0) name += ' ${flag.paramDescription}';
 				if(name.length > max) max = name.length;
 				return max;
 			}, 0);
 			
-			function addFlag(name:String, doc:String) {
-				if(doc == null) doc = '';
-				addLine(indent(name.lpad(' ', maxFlagLength) + ' : ' + indent(doc, maxFlagLength + 3).trim(), 6));
+			var ep = ~/^@param.*$/gim;
+			function addFlag(name:String, doc:String, paramDescription:String) {
+				if(doc == null) {
+					doc = '';
+				} else {
+					//Filter out the lines with @param
+					doc = ep.map(doc, function(e : EReg) return "");
+				}
+				addLine(indent(('$name $paramDescription').rpad(' ', maxFlagLength) +  ' : ' + indent(doc, maxFlagLength + 3).trim(), 6));
 			}
 			
 			addLine('');
 			addLine('  Flags:');
 			
 			for(flag in spec.flags) {
-				addFlag(nameOf(flag), formatDoc(flag.doc));
+				addFlag(nameOf(flag), formatDoc(flag.doc), flag.paramDescription);
 			}
 		}
 		

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -13,6 +13,7 @@ class RunTests {
 			new TestAliasDisabled(),
 			new TestPrompt(),
 			new TestOptional(),
+			new TestDoc(),
 		])).handle(Runner.exit);
 		
 	}

--- a/tests/TestDoc.hx
+++ b/tests/TestDoc.hx
@@ -1,0 +1,56 @@
+package;
+
+import tink.cli.*;
+import tink.Cli;
+import tink.unit.Assert.*;
+import haxe.ds.StringMap;
+
+using tink.CoreApi;
+
+@:asserts
+class TestDoc {
+	public function new() {}
+
+	public function doc() {
+		var command = new FlagDoc();
+
+		var result = 
+		'\n' + 
+		'  Usage: root\n\n' +
+		'  Flags:\n' +
+		'  --name, -n   : No parameter\n' +
+		'  --path, -p <directory>            : Do search in path\n' +
+		'  --unusedParameter, -u <parameter> : Do search in path\n';
+
+		result = StringTools.replace(result, " ", "");
+		asserts.assert(result == StringTools.replace(Cli.getDoc(command, new tink.cli.doc.DefaultFormatter("root")), " ", ""));	
+		return asserts.done();
+	}
+}
+
+class FlagDoc extends DebugCommand {
+	
+	/**
+        No parameter
+    **/
+	@:flag('name')	
+	public var name:String = null;
+	
+	/**
+        @param <directory>
+        Do search in path
+	**/
+	@:flag('path')	
+	public var path:String = null;
+
+	/**
+        @param <parameter>
+        Do search in path
+        @param unused parameter
+    **/
+	@:flag('unusedParameter')	
+	public var unusedParameter:String = null;
+
+	@:defaultCommand
+	public function run(args:Rest<String>) {}
+}


### PR DESCRIPTION
This commit introduces the ability to add a parameter describtion for a flag, so it will appear in the in the syntax of the doc of the cli.
This way you can write clis that gives better hinting of how to use the cli based app.

Parameters are marked with '@param' following the Javadoc-styled documentation standard.
The following example has a flag called 'path' that expects a directory name

class MyFlags {
 /**
        @param <directory>
        Search in 'directory'
 **/
@:flag('path')
 public var path:String = null;
 .
 .
 .
}

Cli.getDoc(new MyFlags(), new tink.cli.doc.DefaultFormatter() will then give this output:

Usage:
 --path, -p<directory> : Search in path of 'directory'

- Only the first occurence of @param is used since a flag only accepts one value,
- Lines with @params are removed from the comments before the are added to the doc of the flag.