### PR TITLE
allow empty string in @:command("", "foo", "bar")

### DIFF
--- a/src/tink/cli/Macro.hx
+++ b/src/tink/cli/Macro.hx
@@ -294,7 +294,11 @@ class Macro {
 					case [{params: []}]:
 						commands.push(field.name);
 					case [{params: params}]:
-						for(p in params) commands.push(p.getString().sure());
+						for(p in params) 
+                            if (p.getString().sure() == "")
+                                commands.push(field.name);
+                            else 
+                                commands.push(p.getString().sure());
 					case v:
 						v[1].pos.makeFailure('Multiple @:command meta is not allowed').sure();
 				}

--- a/tests/TestCommand.hx
+++ b/tests/TestCommand.hx
@@ -48,6 +48,16 @@ class TestCommand {
 		return Cli.process([cmd], command)
 			.map(function(_) return assert(command.result() == 'multi'));
 	}
+
+	@:describe('Multi with "" taking name from function')
+	@:variant('multi_again1')
+	@:variant('multi_again2')
+	@:variant('multi_again')
+	public function testMultiNameAgain(cmd:String) {
+		var command = new EntryCommand();
+		return Cli.process([cmd], command)
+			.map(function(_) return assert(command.result() == 'multi_again'));
+	}
 	
 	@:describe('Rest Arguments')
 	@:variant(['rest', 'a', 'b'], null)
@@ -123,7 +133,12 @@ class EntryCommand extends DebugCommand {
 	public function multi() {
 		debug = 'multi';
 	}
-	
+
+	@:command('', 'multi_again1', 'multi_again2')
+	public function multi_again() {
+		debug = 'multi_again';
+	}
+
 	@:command
 	public function rest(a:String, b:String, c:Rest<String>, d:String) {
 		debug = 'rest $a $b ${c.join(',')} $d';


### PR DESCRIPTION
This PR allows empty string in `@:command("", "foo", "bar") function xx() {}` to be developed to the function name (responding to `"xx"` in addition to `"foo"` and to `"bar"`).

Multiple entries in `@:command("foo", "bar") public function xx() {}` already allow to give aliases  but in that case no `xx` command is generated. 

Consider:

```haxe
@:command('slc', 'superlongcommandboringthehell') function superlongcommandboringthehell() {...}
// VS
@:command('slc', '') function superlongcommandboringthehell()  {...}
```

Which are then equivalent.
Hope it makes sense ;)