### PR TITLE
Update quick-start.md

### DIFF
--- a/getting-started/quick-start.md
+++ b/getting-started/quick-start.md
@@ -22,7 +22,7 @@ class Tool {
 	
 	public var verbose:Bool;
 	
-	public function new() {}
+	public function new() {verbose = false;}
 	
 	@:defaultCommand
 	public function hello(name:String) {


### PR DESCRIPTION
Set a default value for the class field `verbose`. Unless an initial value is set for the class field, execution using node will prompt for the class field value when run even without the flag.